### PR TITLE
モジュールの呼び出し方を変更

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -1,0 +1,19 @@
+name: Spec
+on:
+  push:
+    paths:
+      - '**/*.rb'
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '2.7'
+        bundler-cache: true
+    - name: Install dependencies
+      run: bundle install
+    - name: Run RSpec
+      run: bundle exec rspec

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Gemfile.lock
 
 # rspec failure tracking
 .rspec_status
+
+test.rb

--- a/lib/aissue/cli.rb
+++ b/lib/aissue/cli.rb
@@ -1,10 +1,10 @@
 require 'thor'
 require 'dotenv/load'
-require_relative 'util'
+require_relative 'helper'
 
 module Aissue
   class CLI < Thor
-    include Aissue::Util
+    extend Aissue::Helper
 
     desc "start", "Start the Aissue CLI"
     def start

--- a/lib/aissue/cli.rb
+++ b/lib/aissue/cli.rb
@@ -4,7 +4,7 @@ require_relative 'helper'
 
 module Aissue
   class CLI < Thor
-    extend Aissue::Helper
+    include Aissue::Helper
 
     desc "start", "Start the Aissue CLI"
     def start

--- a/lib/aissue/helper.rb
+++ b/lib/aissue/helper.rb
@@ -16,7 +16,10 @@ module Aissue
     end
   end
 
-  module Util
+  module Helper
+
+    private
+
     # OpenAI API
     def post_openai(prompt, model: ENV['GPT_MODEL'], temperature: 0.7, json: false)
       data = {

--- a/lib/aissue/issue.rb
+++ b/lib/aissue/issue.rb
@@ -1,9 +1,9 @@
-require_relative 'util'
+require_relative 'helper'
 
 module Aissue
-  include Aissue::Util
-
   class Issue
+    extend Aissue::Helper
+
     class << self
       def rescue(e)
         repo_root = Dir.pwd

--- a/lib/aissue/version.rb
+++ b/lib/aissue/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aissue
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/lib/aissue/version.rb
+++ b/lib/aissue/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aissue
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/aissue_spec.rb
+++ b/spec/aissue_spec.rb
@@ -4,8 +4,4 @@ RSpec.describe Aissue do
   it "has a version number" do
     expect(Aissue::VERSION).not_to be nil
   end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe Aissue::CLI do
+  it "can use start" do
+    expect(Aissue::CLI.methods).to include(:start)
+  end
+end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe Aissue::Helper do
+  it "methods" do
+    methods = [:post_openai, :get_file_contents, :create_issue, :record_issue]
+    methods.each do |method|
+      expect(Aissue::Helper.private_method_defined?(method)).to be true
+    end
+  end
+end

--- a/spec/issue_spec.rb
+++ b/spec/issue_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe Aissue::Issue do
+  it "can use rescue" do
+    expect(Aissue::Issue.methods).to include(:rescue)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require "aissue"
+require "aissue/helper"
+require "aissue/cli"
+require "aissue/issue"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/test.rb
+++ b/test.rb
@@ -1,7 +1,0 @@
-require_relative 'lib/aissue/issue'
-
-begin
-  100 / 0
-rescue => e
-  Aissue::Issue.rescue(e)
-end

--- a/test.rb
+++ b/test.rb
@@ -1,0 +1,7 @@
+require_relative 'lib/aissue/issue'
+
+begin
+  100 / 0
+rescue => e
+  Aissue::Issue.rescue(e)
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Refactor: `Aissue::Util`モジュールを`Aissue::Helper`に名前変更し、クラスメソッドとして利用可能に。
- Test: RSpecテストを追加および更新し、例外処理やCLIの動作を確認。
- Chore: GitHub Actionsワークフローを設定し、RubyプロジェクトでRSpecテストを自動実行。
- Chore: `.gitignore`に`test.rb`を追加。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->